### PR TITLE
Deprecation, Syntax highlighting csslintrc and Beautifying

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,8 @@ define(function (require, exports, module) {
 		DocumentManager         = brackets.getModule("document/DocumentManager"),
 		FileSystem              = brackets.getModule("filesystem/FileSystem"),
 		ProjectManager          = brackets.getModule("project/ProjectManager"),
-		PreferencesManager      = brackets.getModule("preferences/PreferencesManager");
+		PreferencesManager      = brackets.getModule("preferences/PreferencesManager"),
+		LanguageManager         = brackets.getModule("language/LanguageManager");
 
 	var pm = PreferencesManager.getExtensionPrefs("csslint"),
 		defaults;
@@ -140,6 +141,8 @@ define(function (require, exports, module) {
     }
 
     AppInit.appReady(function () {
+
+        LanguageManager.getLanguage("json").addFileName(_configFileName);
 
         CodeInspection.register("css", {
             name: "CSSLint",

--- a/main.js
+++ b/main.js
@@ -1,83 +1,88 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, window, CSSLint, Mustache */
+/*global define, brackets, $, CSSLint */
 
 define(function (require, exports, module) {
-	'use strict';
+    "use strict";
 
-	var AppInit                 = brackets.getModule("utils/AppInit"),
-		CodeInspection			= brackets.getModule("language/CodeInspection"),
-		DocumentManager         = brackets.getModule("document/DocumentManager"),
-		FileSystem              = brackets.getModule("filesystem/FileSystem"),
-		ProjectManager          = brackets.getModule("project/ProjectManager"),
-		PreferencesManager      = brackets.getModule("preferences/PreferencesManager"),
-		LanguageManager         = brackets.getModule("language/LanguageManager");
+    var DocumentManager    = brackets.getModule("document/DocumentManager"),
+        FileSystem         = brackets.getModule("filesystem/FileSystem"),
+        CodeInspection     = brackets.getModule("language/CodeInspection"),
+        LanguageManager    = brackets.getModule("language/LanguageManager"),
+        PreferencesManager = brackets.getModule("preferences/PreferencesManager"),
+        ProjectManager     = brackets.getModule("project/ProjectManager"),
+        AppInit            = brackets.getModule("utils/AppInit");
 
-	var pm = PreferencesManager.getExtensionPrefs("csslint"),
-		defaults;
+    var pm = PreferencesManager.getExtensionPrefs("csslint"),
+        defaults;
 
-	pm.definePreference("options", "object", {})
-		.on("change", function () {
-			defaults = pm.get("options");
-		});
+    pm.definePreference("options", "object", {})
+        .on("change", function () {
+            defaults = pm.get("options");
+        });
 
-	defaults = pm.get("options");
+    defaults = pm.get("options");
 
-	require("csslint/csslint");
+    require("csslint/csslint");
 
-	var _configFileName = ".csslintrc",
-		config = {};
+    var _configFileName = ".csslintrc",
+        config = {};
 
-	function cssLinter(text, fullPath) {
-		var results;
+    function cssLinter(text) {
+        var results;
 
-		// Merge default CSSLint ruleset with the custom .csslintrc config
-		var ruleset = $.extend(CSSLint.getRuleset(), defaults, config.options);
+        // Merge default CSSLint ruleset with the custom .csslintrc config
+        var ruleset = $.extend(CSSLint.getRuleset(), defaults, config.options);
 
-		// Execute CSSLint
-		results = CSSLint.verify(text, ruleset);
+        // Execute CSSLint
+        results = CSSLint.verify(text, ruleset);
 
-		if (results.messages.length) {
-			var result = { errors: [] };
+        if (results.messages.length) {
+            var result = {
+                errors: []
+            };
 
-			for(var i=0, len=results.messages.length; i<len; i++) {
+            for (var i = 0, len = results.messages.length; i < len; i++) {
 
-				/*
-				Currently the Brackets Lint API doesn't work with warnings that are 'document' level.
-				See bug: https://github.com/adobe/brackets/issues/5452
-				*/
-				var messageOb = results.messages[i];
+                /*
+                Currently the Brackets Lint API doesn't work with warnings that are 'document' level.
+                See bug: https://github.com/adobe/brackets/issues/5452
+                */
+                var messageOb = results.messages[i];
 
-				if(!messageOb.line) continue;
-				//default
-				var type = CodeInspection.Type.WARNING;
+                if (!messageOb.line) continue;
+                //default
+                var type = CodeInspection.Type.WARNING;
 
-				if(messageOb.type === "error") {
-					type = CodeInspection.Type.ERROR;
-				} else if(messageOb.type === "warning") {
-					type = CodeInspection.Type.WARNING;
-				}
+                if (messageOb.type === "error") {
+                    type = CodeInspection.Type.ERROR;
+                } else if (messageOb.type === "warning") {
+                    type = CodeInspection.Type.WARNING;
+                }
 
-				var message = messageOb.rule.name + " - " + messageOb.message;
-				message += " (" + messageOb.rule.id + ")";
+                var message = messageOb.rule.name + " - " + messageOb.message;
+                message += " (" + messageOb.rule.id + ")";
 
-				result.errors.push({
-					pos: {line:messageOb.line-1, ch:messageOb.col},
-					message:message,
+                result.errors.push({
+                    pos: {
+                        line: messageOb.line - 1,
+                        ch: messageOb.col
+                    },
+                    message: message,
 
-					type:type
-				});
-			}
+                    type: type
+                });
+            }
 
-			return result;
-		} else {
-			//no errors
-			return null;
-		}
+            return result;
+        } else {
+            //no errors
+            return null;
+        }
 
-	}
+    }
 
 
-	/**
+    /**
      * Loads project-wide CSSLint configuration.
      *
      * CSSLint project file should be located at <Project Root>/.csslintrc. It
@@ -98,7 +103,7 @@ define(function (require, exports, module) {
         file.read(function (err, content) {
             if (!err) {
                 var cfg = {};
-		try {
+                try {
                     config = JSON.parse(content);
                 } catch (e) {
                     console.error("CSSLint: Error parsing " + file.fullPath + ". Details: " + e);
@@ -119,7 +124,7 @@ define(function (require, exports, module) {
      */
     function tryLoadConfig() {
         /**
-         * Makes sure JSHint is re-ran when the config is reloaded
+         * Makes sure CSSLint is re-ran when the config is reloaded
          *
          * This is a workaround due to some loading issues in Sprint 31.
          * See bug for details: https://github.com/adobe/brackets/issues/5442
@@ -157,7 +162,7 @@ define(function (require, exports, module) {
                 }
             });
 
-       ProjectManager
+        ProjectManager
             .on("projectOpen.csslint", function () {
                 tryLoadConfig();
             });

--- a/main.js
+++ b/main.js
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
             scanFile: cssLinter
         });
 
-        $(DocumentManager)
+        DocumentManager
             .on("documentSaved.csslint documentRefreshed.csslint", function (e, document) {
                 // if this project's .csslintrc config has been updated, reload
                 if (document.file.fullPath === ProjectManager.getProjectRoot().fullPath + _configFileName) {
@@ -154,7 +154,7 @@ define(function (require, exports, module) {
                 }
             });
 
-        $(ProjectManager)
+       ProjectManager
             .on("projectOpen.csslint", function () {
                 tryLoadConfig();
             });


### PR DESCRIPTION
I am just working on my own extension and was annoyed by getting my console filled with warnings, so I made this fix.

And as I had it open I also added JSON syntax highlighting for the `.csslintrc` file and fixed the whitespace.

Feel free to merge any or all commits.